### PR TITLE
DB refactor

### DIFF
--- a/api/server/agent.go
+++ b/api/server/agent.go
@@ -22,9 +22,12 @@ func (tapi ToDDApi) Agent(w http.ResponseWriter, r *http.Request) {
 	// Retrieve query values
 	values := r.URL.Query()
 
-	var agent_list []defs.AgentAdvert
-
-	var tdb = db.NewToddDB(tapi.cfg)
+	agentList, err := tapi.tdb.GetAgents()
+	if err != nil {
+		log.Errorln(err)
+		http.Error(w, "Internal Error", 500)
+		return
+	}
 
 	// Make sure UUID string is provided
 	if uuid, ok := values["uuid"]; ok {

--- a/api/server/agent.go
+++ b/api/server/agent.go
@@ -11,10 +11,11 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Mierdin/todd/agent/defs"
-	"github.com/Mierdin/todd/db"
 	"net/http"
 	"strings"
+
+	"github.com/Mierdin/todd/agent/defs"
+	log "github.com/Sirupsen/logrus"
 )
 
 func (tapi ToDDApi) Agent(w http.ResponseWriter, r *http.Request) {
@@ -22,7 +23,7 @@ func (tapi ToDDApi) Agent(w http.ResponseWriter, r *http.Request) {
 	// Retrieve query values
 	values := r.URL.Query()
 
-	agentList, err := tapi.tdb.GetAgents()
+	agent_list, err := tapi.tdb.GetAgents()
 	if err != nil {
 		log.Errorln(err)
 		http.Error(w, "Internal Error", 500)
@@ -35,21 +36,22 @@ func (tapi ToDDApi) Agent(w http.ResponseWriter, r *http.Request) {
 		// Make sure UUID string actually contains something
 		if len(uuid[0]) > 0 {
 			// Let's get the full list so we can identify the right agent if the user specified a short
-			full_agent_list := tdb.DatabasePackage.GetAgents()
+			full_agent_list, _ := tapi.tdb.GetAgents()
 
 			for i := range full_agent_list {
 				if strings.HasPrefix(full_agent_list[i].Uuid, uuid[0]) {
-					agent_list = append(agent_list, tdb.DatabasePackage.GetAgent(full_agent_list[i].Uuid))
+					agent, _ := tapi.tdb.GetAgent(full_agent_list[i].Uuid)
+					agent_list = append(agent_list, *agent)
 					break
 				}
 			}
 
 		} else { // UUID not provided; get all agents
-			agent_list = tdb.DatabasePackage.GetAgents()
+			agent_list, _ = tapi.tdb.GetAgents()
 		}
 
 	} else { // UUID not provided; get all agents
-		agent_list = tdb.DatabasePackage.GetAgents()
+		agent_list, _ = tapi.tdb.GetAgents()
 	}
 
 	// If there are no agents, return an empty slice, not a nil slice - this

--- a/api/server/groups.go
+++ b/api/server/groups.go
@@ -14,8 +14,6 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
-
-	"github.com/Mierdin/todd/db"
 )
 
 func (tapi ToDDApi) Groups(w http.ResponseWriter, r *http.Request) {

--- a/api/server/groups.go
+++ b/api/server/groups.go
@@ -22,14 +22,11 @@ func (tapi ToDDApi) Groups(w http.ResponseWriter, r *http.Request) {
 
 	log.Info("Received request for group map")
 
-	var tdb = db.NewToddDB(tapi.cfg)
-
-	groupmap := tdb.DatabasePackage.GetGroupMap()
-
-	// If there are no objects, return an empty slice, not a nil slice - this
-	// prevents this API from returning "null"
-	if groupmap == nil {
-		groupmap = map[string]string{}
+	groupmap, err := tapi.tdb.GetGroupMap()
+	if err != nil {
+		log.Errorln(err)
+		http.Error(w, "Internal Error", 500)
+		return
 	}
 
 	response, err := json.MarshalIndent(groupmap, "", "  ")

--- a/api/server/object.go
+++ b/api/server/object.go
@@ -17,7 +17,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/Mierdin/todd/db"
 	"github.com/Mierdin/todd/server/objects"
 )
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -11,8 +11,8 @@ package api
 import (
 	"fmt"
 	"net/http"
-	"os"
 
+	"github.com/Mierdin/todd/db"
 	log "github.com/Sirupsen/logrus"
 
 	"github.com/Mierdin/todd/config"
@@ -20,11 +20,19 @@ import (
 
 type ToDDApi struct {
 	cfg config.Config
+	tdb db.DatabasePackage
 }
 
-func (tapi ToDDApi) Start(cfg config.Config) {
+func (tapi ToDDApi) Start(cfg config.Config) error {
 
 	tapi.cfg = cfg
+
+	tdb, err := db.NewToddDB(tapi.cfg)
+	if err != nil {
+		return err
+	}
+
+	tapi.tdb = tdb
 
 	// TODO(mierdin): This needs a lot of work. Not only is the version very static
 	// (which is okay for now until we hit a new version)
@@ -42,9 +50,5 @@ func (tapi ToDDApi) Start(cfg config.Config) {
 	serve_url := fmt.Sprintf("%s:%s", tapi.cfg.API.Host, tapi.cfg.API.Port)
 
 	log.Infof("Serving ToDD Server API at: %s\n", serve_url)
-	err := http.ListenAndServe(serve_url, nil)
-	if err != nil {
-		log.Error("Error starting API")
-		os.Exit(1)
-	}
+	return http.ListenAndServe(serve_url, nil)
 }

--- a/api/server/testrun.go
+++ b/api/server/testrun.go
@@ -85,25 +85,18 @@ func (tapi ToDDApi) Run(w http.ResponseWriter, r *http.Request) {
 
 // TestData will retrieve clean test data by test UUID
 func (tapi ToDDApi) TestData(w http.ResponseWriter, r *http.Request) {
-	// Retrieve query values
-	values := r.URL.Query()
-
-	var testData string
-
 	// Make sure UUID string is provided
-	if testUuid, ok := values["testUuid"]; ok {
-
-		// Make sure UUID string actually contains something
-		if len(testUuid[0]) > 0 {
-			testData, _ = tapi.tdb.GetCleanTestData(testUuid[0])
-		} else {
-			fmt.Fprint(w, "Error, test UUID not found.")
-		}
-
-	} else { // UUID not provided; get all agents
+	uuid := r.URL.Query().Get("uuid")
+	if uuid == "" {
 		fmt.Fprint(w, "Error, test UUID not provided.")
+		return
+	}
+
+	testData, err := tapi.tdb.GetCleanTestData(uuid)
+	if err != nil {
+		fmt.Fprint(w, "Error, test UUID not found.")
+		return
 	}
 
 	fmt.Fprint(w, testData)
-
 }

--- a/api/server/testrun.go
+++ b/api/server/testrun.go
@@ -86,7 +86,7 @@ func (tapi ToDDApi) Run(w http.ResponseWriter, r *http.Request) {
 // TestData will retrieve clean test data by test UUID
 func (tapi ToDDApi) TestData(w http.ResponseWriter, r *http.Request) {
 	// Make sure UUID string is provided
-	uuid := r.URL.Query().Get("uuid")
+	uuid := r.URL.Query().Get("testUuid")
 	if uuid == "" {
 		fmt.Fprint(w, "Error, test UUID not provided.")
 		return

--- a/api/server/testrun.go
+++ b/api/server/testrun.go
@@ -16,7 +16,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 
-	"github.com/Mierdin/todd/db"
 	"github.com/Mierdin/todd/server/objects"
 	"github.com/Mierdin/todd/server/testrun"
 )
@@ -96,10 +95,9 @@ func (tapi ToDDApi) TestData(w http.ResponseWriter, r *http.Request) {
 
 		// Make sure UUID string actually contains something
 		if len(testUuid[0]) > 0 {
-			testData = tdb.DatabasePackage.GetCleanTestData(testUuid[0])
+			testData, _ = tapi.tdb.GetCleanTestData(testUuid[0])
 		} else {
 			fmt.Fprint(w, "Error, test UUID not found.")
-	testData, err := tapi.tdb.GetCleanTestData(testUUID)
 		}
 
 	} else { // UUID not provided; get all agents

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -235,8 +235,8 @@ func (rmq rabbitMQComms) ListenForAgent(assets map[string]map[string]string) {
 			// Asset list is empty, so we can continue
 			if len(assetList) == 0 {
 
-				var tdb = db.NewToddDB(rmq.config)
-				tdb.DatabasePackage.SetAgent(agent)
+				var tdb, _ = db.NewToddDB(rmq.config)
+				tdb.SetAgent(agent)
 
 				// This block of code checked that the agent time was within a certain range of the server time. If there was a large enough
 				// time skew, the agent advertisement would be rejected.

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -840,8 +840,8 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 				// TODO(mierdin): Need to handle this error
 
 				log.Debugf("Agent %s is '%s' regarding test %s. Writing to DB.", sasr.AgentUuid, sasr.Status, sasr.TestUuid)
-				var tdb = db.NewToddDB(rmq.config)
-				tdb.DatabasePackage.SetAgentTestStatus(sasr.TestUuid, sasr.AgentUuid, sasr.Status)
+				tdb, _ := db.NewToddDB(rmq.config)                                 // TODO(kale) : Handler error
+				tdb.SetAgentTestStatus(sasr.TestUuid, sasr.AgentUuid, sasr.Status) // TODO(kale) : Handler error
 
 			case "TestData":
 
@@ -849,8 +849,8 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 				err = json.Unmarshal(d.Body, &utdr)
 				// TODO(mierdin): Need to handle this error
 
-				var tdb = db.NewToddDB(rmq.config)
-				err = tdb.DatabasePackage.SetAgentTestData(utdr.TestUuid, utdr.AgentUuid, utdr.TestData)
+				tdb, _ := db.NewToddDB(rmq.config) // TODO(kale) : Handler error
+				err = tdb.SetAgentTestData(utdr.TestUuid, utdr.AgentUuid, utdr.TestData)
 				// TODO(mierdin): Need to handle this error
 
 				// Send task to the agent that says to delete the entry
@@ -860,7 +860,7 @@ func (rmq rabbitMQComms) ListenForResponses(stopListeningForResponses *chan bool
 				rmq.SendTask(utdr.AgentUuid, dtdt)
 
 				// FInally, set the status for this agent in the test to "finished"
-				tdb.DatabasePackage.SetAgentTestStatus(dtdt.TestUuid, utdr.AgentUuid, "finished")
+				tdb.SetAgentTestStatus(dtdt.TestUuid, utdr.AgentUuid, "finished") // TODO(kale) : Handler error
 
 			default:
 				log.Errorf(fmt.Sprintf("Unexpected type value for received response: %s", base_msg.Type))

--- a/db/db.go
+++ b/db/db.go
@@ -11,66 +11,64 @@
 package db
 
 import (
-	"os"
+	"errors"
 
 	"github.com/Mierdin/todd/agent/defs"
 	"github.com/Mierdin/todd/config"
 	"github.com/Mierdin/todd/server/objects"
-	log "github.com/Sirupsen/logrus"
+)
+
+var (
+	ErrInvalidDBPlugin = errors.New("Invalid DB plugin in config file")
+	ErrNotExist        = errors.New("Value does not exist")
 )
 
 // DatabasePackage represents all of the behavior that a ToDD database plugin must support
 type DatabasePackage interface {
 
 	// (no args)
-	Init()
+	Init() error
 
 	// (agent advertisement to set)
-	SetAgent(defs.AgentAdvert)
+	SetAgent(defs.AgentAdvert) error
 
-	GetAgent(string) defs.AgentAdvert
-	GetAgents() []defs.AgentAdvert
+	GetAgent(string) (*defs.AgentAdvert, error)
+	GetAgents() ([]defs.AgentAdvert, error)
 
 	// (agent advertisement to remove)
-	RemoveAgent(defs.AgentAdvert)
+	RemoveAgent(defs.AgentAdvert) error
 
-	SetObject(objects.ToddObject)
-	GetObjects(string) []objects.ToddObject
-	DeleteObject(string, string)
+	SetObject(objects.ToddObject) error
+	GetObjects(string) ([]objects.ToddObject, error)
+	DeleteObject(string, string) error
 
-	GetGroupMap() map[string]string
-	SetGroupMap(map[string]string)
+	GetGroupMap() (map[string]string, error)
+	SetGroupMap(map[string]string) error
 
 	// Testing
 	InitTestRun(string, map[string]map[string]string) error
 	SetAgentTestStatus(string, string, string) error
-	GetTestStatus(string) map[string]string
+	GetTestStatus(string) (map[string]string, error)
 	SetAgentTestData(string, string, string) error
-	GetAgentTestData(string, string) map[string]string
-	WriteCleanTestData(string, string)
-	GetCleanTestData(string) string
+	GetAgentTestData(string, string) (map[string]string, error)
+	WriteCleanTestData(string, string) error
+	GetCleanTestData(string) (string, error)
 }
 
-// toddDatabase is a struct to hold anything that satisfies the databasePackage interface
-type toddDatabase struct {
-	DatabasePackage
-}
-
-// NewToDDComms will create a new instance of toddDatabase, and load the desired
+// NewToddDB will create a new instance of toddDatabase, and load the desired
 // databasePackage-compatible comms package into it.
-func NewToddDB(cfg config.Config) *toddDatabase {
+func NewToddDB(cfg config.Config) (DatabasePackage, error) {
 
 	// Create toddDatabase instance
-	var tdb toddDatabase
+	var tdb DatabasePackage
 
 	// Load the appropriate DB package based on config file
 	switch cfg.DB.Plugin {
 	case "etcd":
-		tdb.DatabasePackage = newEtcdDB(cfg)
+		tdb = newEtcdDB(cfg)
 	default:
-		log.Error("Invalid DB plugin in config file")
-		os.Exit(1)
+		return nil, ErrInvalidDBPlugin
 	}
 
-	return &tdb
+	return tdb, nil
 }

--- a/db/etcd.go
+++ b/db/etcd.go
@@ -321,8 +321,7 @@ func (etcddb *etcdDB) GetGroupMap() (map[string]string, error) {
 
 	resp, err := etcddb.keysAPI.Get(context.Background(), keyStr, &client.GetOptions{Recursive: true})
 	if err != nil {
-		fmt.Println(err)
-		log.Warn("Error retrieving group mapping")
+		log.Warnf("Error retrieving group mapping: %v", err)
 		return retMap, nil
 	}
 
@@ -493,8 +492,7 @@ func (etcddb *etcdDB) GetAgentTestData(testUUID, sourceGroup string) (map[string
 
 	resp, err := etcddb.keysAPI.Get(context.Background(), keyStr, &client.GetOptions{Recursive: true})
 	if err != nil {
-		fmt.Println(err)
-		log.Errorf("Error - empty test encountered: %s", testUUID)
+		log.Errorf("Error - empty test encountered for %q: %v", testUUID, err)
 		return nil, err
 	}
 

--- a/db/etcd.go
+++ b/db/etcd.go
@@ -95,9 +95,9 @@ func (etcddb *etcdDB) SetAgent(adv defs.AgentAdvert) error {
 
 // GetAgent will retrieve a specific agent from the database by UUID
 func (etcddb *etcdDB) GetAgent(uuid string) (*defs.AgentAdvert, error) {
-	log.Printf("Getting /todd/agents/%s' key value", uuid)
-
 	keyStr := fmt.Sprintf("/todd/agents/%s", uuid)
+
+	log.Printf("Getting %q key value", keyStr)
 
 	resp, err := etcddb.keysAPI.Get(context.Background(), keyStr, &client.GetOptions{Recursive: true})
 	if err != nil {
@@ -115,6 +115,7 @@ func (etcddb *etcdDB) GetAgent(uuid string) (*defs.AgentAdvert, error) {
 	return adv, nil
 }
 
+// nodeToAgentAdvert takes a etcd Node representing an AgentAdvert and returns an AgentAdvert
 func nodeToAgentAdvert(node *client.Node, expectedUUID string) (*defs.AgentAdvert, error) {
 	adv := new(defs.AgentAdvert)
 
@@ -128,7 +129,7 @@ func nodeToAgentAdvert(node *client.Node, expectedUUID string) (*defs.AgentAdver
 	// We want to use the TTLDuration field from etcd for simplicity
 	adv.Expires = node.TTLDuration()
 
-	// The etcd key should always match the inner JSON, so let's panic (for now) if this ever happens
+	// The etcd key should always match the inner JSON
 	if expectedUUID != adv.Uuid {
 		return nil, errors.New("UUID in etcd does not match inner JSON text")
 	}
@@ -450,8 +451,7 @@ func (etcddb *etcdDB) GetTestStatus(testUUID string) (map[string]string, error) 
 
 	resp, err := etcddb.keysAPI.Get(context.Background(), keyStr, &client.GetOptions{Recursive: true})
 	if err != nil {
-		fmt.Println(err)
-		log.Errorf("Error - empty test encountered: %s", testUUID)
+		log.Errorf("Error - empty test encountered for %q: %v", testUUID, err)
 		return retMap, nil
 	}
 

--- a/server/grouping/grouping.go
+++ b/server/grouping/grouping.go
@@ -26,13 +26,13 @@ import (
 // return a map that contains the resulting group for each agent UUID.
 func CalculateGroups(cfg config.Config) {
 
-	tdb := db.NewToddDB(cfg)
+	tdb, _ := db.NewToddDB(cfg)
 
 	// Retrieve all currently active agents
-	agents := tdb.DatabasePackage.GetAgents()
+	agents, _ := tdb.GetAgents()
 
 	// Retrieve all objects with type "group"
-	group_objs := tdb.DatabasePackage.GetObjects("group")
+	group_objs, _ := tdb.GetObjects("group")
 
 	// Cast retrieved slice of ToddObject interfaces to actual GroupObjects
 	groups := make([]objects.GroupObject, len(group_objs))
@@ -69,7 +69,7 @@ next:
 	}
 
 	// Write results to database
-	tdb.DatabasePackage.SetGroupMap(groupmap)
+	tdb.SetGroupMap(groupmap)
 
 	// Send notifications to each agent to let them know what group they're in, so they can cache it
 	var tc = comms.NewToDDComms(cfg)

--- a/server/grouping/grouping.go
+++ b/server/grouping/grouping.go
@@ -26,13 +26,22 @@ import (
 // return a map that contains the resulting group for each agent UUID.
 func CalculateGroups(cfg config.Config) {
 
-	tdb, _ := db.NewToddDB(cfg)
+	tdb, err := db.NewToddDB(cfg)
+	if err != nil {
+		log.Fatalf("Error connecting to DB: %v", err)
+	}
 
 	// Retrieve all currently active agents
-	agents, _ := tdb.GetAgents()
+	agents, err := tdb.GetAgents()
+	if err != nil {
+		log.Fatalf("Error retrieving agents: %v", err)
+	}
 
 	// Retrieve all objects with type "group"
-	group_objs, _ := tdb.GetObjects("group")
+	group_objs, err := tdb.GetObjects("group")
+	if err != nil {
+		log.Fatalf("Error retrieving groups: %v", err)
+	}
 
 	// Cast retrieved slice of ToddObject interfaces to actual GroupObjects
 	groups := make([]objects.GroupObject, len(group_objs))
@@ -69,7 +78,10 @@ next:
 	}
 
 	// Write results to database
-	tdb.SetGroupMap(groupmap)
+	err = tdb.SetGroupMap(groupmap)
+	if err != nil {
+		log.Fatalf("Error setting group map: %v", err)
+	}
 
 	// Send notifications to each agent to let them know what group they're in, so they can cache it
 	var tc = comms.NewToDDComms(cfg)

--- a/server/main.go
+++ b/server/main.go
@@ -55,12 +55,20 @@ func main() {
 	assets := serveAssets(cfg)
 
 	// Perform database initialization tasks
-	var tdb = db.NewToddDB(cfg)
-	tdb.DatabasePackage.Init()
+	tdb, err := db.NewToddDB(cfg)
+	if err != nil {
+		log.Fatalf("Error setting up database: %v\n", err)
+	}
+
+	if err := tdb.Init(); err != nil {
+		log.Fatalf("Error initializing database: %v\n", err)
+	}
 
 	// Initialize API
 	var tapi toddapi.ToDDApi
-	go tapi.Start(cfg)
+	go func() {
+		log.Fatal(tapi.Start(cfg))
+	}()
 
 	// Start listening for agent advertisements
 	var tc = comms.NewToDDComms(cfg)

--- a/server/testrun/testrun.go
+++ b/server/testrun/testrun.go
@@ -33,8 +33,14 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 	testUuid := hostresources.GenerateUuid()
 
 	// Retrieve current group map
-	tdb, _ := db.NewToddDB(cfg)
-	allGroupMap, _ := tdb.GetGroupMap()
+	tdb, err := db.NewToddDB(cfg)
+	if err != nil {
+		log.Fatalf("Error connecting to DB: %v", err)
+	}
+	allGroupMap, err := tdb.GetGroupMap()
+	if err != nil {
+		log.Fatalf("Error retrieving group map: %v", err)
+	}
 
 	// sourceOverride is a flag to pass into the executeTest function so that it knows how to return test data if the source group has been overridden
 	sourceOverride := false
@@ -83,7 +89,7 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 
 	// Initialize test in database. This will create an entry for this test under the UUID we just created, and will also write the
 	// list of agents participating in this test, with some kind of default status, for other goroutines to update with a further status.
-	err := tdb.InitTestRun(testUuid, testAgentMap)
+	err = tdb.InitTestRun(testUuid, testAgentMap)
 	if err != nil {
 		log.Fatal("Problem initializing testrun in database.")
 		return "failure"
@@ -101,7 +107,10 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 		// This is a group target type, so we are deriving target IPs from the DefaultAddr property of this agent.
 		var targetIPs []string
 		for uuid, _ := range testAgentMap["targets"] {
-			agent, _ := tdb.GetAgent(uuid)
+			agent, err := tdb.GetAgent(uuid)
+			if err != nil {
+				log.Fatalf("Error retrieving agent: %v", err)
+			}
 			targetIPs = append(targetIPs, agent.DefaultAddr)
 		}
 		sourceTr.Targets = targetIPs
@@ -172,14 +181,20 @@ func executeTestRun(testAgentMap map[string]map[string]string, testUuid string, 
 	// Sleep for 2 seconds so that the client moniting can connect first
 	time.Sleep(2000 * time.Millisecond)
 
-	tdb, _ := db.NewToddDB(cfg)
+	tdb, err := db.NewToddDB(cfg) // TODO(vcabbage): Pass tdb in instead of creating new connection?
+	if err != nil {
+		log.Fatalf("Error connecting to DB: %v", err)
+	}
 
 	// First, let's just keep retrieving statuses until all of the agents are reporting ready
 readyloop:
 	for {
 		time.Sleep(1000 * time.Millisecond)
 
-		testStatuses, _ := tdb.GetTestStatus(testUuid)
+		testStatuses, err := tdb.GetTestStatus(testUuid)
+		if err != nil {
+			log.Fatalf("Error retrieving test status: %v", err)
+		}
 		for _, status := range testStatuses {
 			switch true {
 			case status == "fail":
@@ -213,7 +228,10 @@ readyloop:
 
 			time.Sleep(1000 * time.Millisecond)
 
-			testStatuses, _ := tdb.GetTestStatus(testUuid)
+			testStatuses, err := tdb.GetTestStatus(testUuid)
+			if err != nil {
+				log.Fatalf("Error retrieving test status: %v", err)
+			}
 
 			// We're creating this map to hold ONLY the targets that are in testStatuses (which also contains sources)
 			targetStatuses := make(map[string]string)
@@ -263,7 +281,10 @@ finishedloop:
 	for {
 		time.Sleep(1000 * time.Millisecond)
 
-		testStatuses, _ := tdb.GetTestStatus(testUuid)
+		testStatuses, err := tdb.GetTestStatus(testUuid)
+		if err != nil {
+			log.Fatalf("Error retrieving test status: %v", err)
+		}
 		for agent, status := range testStatuses {
 			switch true {
 			case status == "fail":
@@ -276,7 +297,10 @@ finishedloop:
 		break
 	}
 
-	uncondensedData, _ := tdb.GetAgentTestData(testUuid, trObj.Spec.Source["name"])
+	uncondensedData, err := tdb.GetAgentTestData(testUuid, trObj.Spec.Source["name"])
+	if err != nil {
+		log.Fatalf("Error retrieving agent test data: %v", err)
+	}
 
 	clean_data_map := cleanTestData(uncondensedData)
 
@@ -383,7 +407,10 @@ retrytcpserver:
 	for {
 		time.Sleep(1000 * time.Millisecond)
 
-		testStatuses, _ := tdb.GetTestStatus(testUuid)
+		testStatuses, err := tdb.GetTestStatus(testUuid)
+		if err != nil {
+			log.Fatalf("Error retrieving test status: %v", err)
+		}
 
 		statuses_json, err := json.Marshal(testStatuses)
 		if err != nil {

--- a/server/testrun/testrun.go
+++ b/server/testrun/testrun.go
@@ -33,8 +33,8 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 	testUuid := hostresources.GenerateUuid()
 
 	// Retrieve current group map
-	var tdb = db.NewToddDB(cfg)
-	allGroupMap := tdb.DatabasePackage.GetGroupMap()
+	tdb, _ := db.NewToddDB(cfg)
+	allGroupMap, _ := tdb.GetGroupMap()
 
 	// sourceOverride is a flag to pass into the executeTest function so that it knows how to return test data if the source group has been overridden
 	sourceOverride := false
@@ -83,7 +83,7 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 
 	// Initialize test in database. This will create an entry for this test under the UUID we just created, and will also write the
 	// list of agents participating in this test, with some kind of default status, for other goroutines to update with a further status.
-	err := tdb.DatabasePackage.InitTestRun(testUuid, testAgentMap)
+	err := tdb.InitTestRun(testUuid, testAgentMap)
 	if err != nil {
 		log.Fatal("Problem initializing testrun in database.")
 		return "failure"
@@ -101,7 +101,7 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 		// This is a group target type, so we are deriving target IPs from the DefaultAddr property of this agent.
 		var targetIPs []string
 		for uuid, _ := range testAgentMap["targets"] {
-			agent := tdb.GetAgent(uuid)
+			agent, _ := tdb.GetAgent(uuid)
 			targetIPs = append(targetIPs, agent.DefaultAddr)
 		}
 		sourceTr.Targets = targetIPs
@@ -172,14 +172,14 @@ func executeTestRun(testAgentMap map[string]map[string]string, testUuid string, 
 	// Sleep for 2 seconds so that the client moniting can connect first
 	time.Sleep(2000 * time.Millisecond)
 
-	var tdb = db.NewToddDB(cfg)
+	tdb, _ := db.NewToddDB(cfg)
 
 	// First, let's just keep retrieving statuses until all of the agents are reporting ready
 readyloop:
 	for {
 		time.Sleep(1000 * time.Millisecond)
 
-		testStatuses := tdb.DatabasePackage.GetTestStatus(testUuid)
+		testStatuses, _ := tdb.GetTestStatus(testUuid)
 		for _, status := range testStatuses {
 			switch true {
 			case status == "fail":
@@ -213,7 +213,7 @@ readyloop:
 
 			time.Sleep(1000 * time.Millisecond)
 
-			testStatuses := tdb.DatabasePackage.GetTestStatus(testUuid)
+			testStatuses, _ := tdb.GetTestStatus(testUuid)
 
 			// We're creating this map to hold ONLY the targets that are in testStatuses (which also contains sources)
 			targetStatuses := make(map[string]string)
@@ -263,7 +263,7 @@ finishedloop:
 	for {
 		time.Sleep(1000 * time.Millisecond)
 
-		testStatuses := tdb.DatabasePackage.GetTestStatus(testUuid)
+		testStatuses, _ := tdb.GetTestStatus(testUuid)
 		for agent, status := range testStatuses {
 			switch true {
 			case status == "fail":
@@ -276,7 +276,7 @@ finishedloop:
 		break
 	}
 
-	uncondensedData := tdb.DatabasePackage.GetAgentTestData(testUuid, trObj.Spec.Source["name"])
+	uncondensedData, _ := tdb.GetAgentTestData(testUuid, trObj.Spec.Source["name"])
 
 	clean_data_map := cleanTestData(uncondensedData)
 
@@ -287,7 +287,7 @@ finishedloop:
 	}
 
 	// Write clean test data to etcd
-	tdb.DatabasePackage.WriteCleanTestData(testUuid, string(clean_data_json))
+	tdb.WriteCleanTestData(testUuid, string(clean_data_json))
 
 	time.Sleep(1000 * time.Millisecond)
 
@@ -377,13 +377,13 @@ retrytcpserver:
 	}
 	defer conn.Close()
 
-	var tdb = db.NewToddDB(cfg)
+	tdb, _ := db.NewToddDB(cfg)
 
 	// Constantly poll for test status, and send statuses to client
 	for {
 		time.Sleep(1000 * time.Millisecond)
 
-		testStatuses := tdb.DatabasePackage.GetTestStatus(testUuid)
+		testStatuses, _ := tdb.GetTestStatus(testUuid)
 
 		statuses_json, err := json.Marshal(testStatuses)
 		if err != nil {


### PR DESCRIPTION
Initial PR based on our conversations and the mailing list emails.

This centers on the DB portion, including:
* Removing the toddDatabase struct
* Returning errors
* Adding the KeysAPI as a field of the etcdDB struct.
* Pointer receivers
* Reduce code nesting with early returns
* Renaming variables to camelCase (mostly just in the db package, to keep the scope of this PR smaller)