### PR TITLE
Initial Unit Testing structure for Client API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/lib/
 docs/_build/
 preso_secret/
 client/repeattest.sh
+*.out

--- a/api/client/agents.go
+++ b/api/client/agents.go
@@ -24,7 +24,7 @@ import (
 // Agents will query the ToDD server for a list of currently registered agents, and will display
 // a list of them to the user. Optionally, the user can provide a subargument containing the UUID of
 // a registered agent, and this function will output more detailed information about that agent.
-func (capi ClientApi) Agents(conf map[string]string, agentUuid string) (error, []defs.AgentAdvert) {
+func (capi ClientApi) Agents(conf map[string]string, agentUuid string) ([]defs.AgentAdvert, error) {
 
 	var agents []defs.AgentAdvert
 
@@ -39,14 +39,14 @@ func (capi ClientApi) Agents(conf map[string]string, agentUuid string) (error, [
 	// Build the request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return err, agents
+		return agents, err
 	}
 
 	// Send the request via a client
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err, agents
+		return agents, err
 	}
 
 	// Defer the closing of the body
@@ -54,16 +54,16 @@ func (capi ClientApi) Agents(conf map[string]string, agentUuid string) (error, [
 	// Read the content into a byte array
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err, agents
+		return agents, err
 	}
 
 	// Marshal API data into object
 	err = json.Unmarshal(body, &agents)
 	if err != nil {
-		return err, agents
+		return agents, err
 	}
 
-	return nil, agents
+	return agents, nil
 }
 
 // DisplayAgents is responsible for displaying a set of Agents to the terminal

--- a/api/client/agents.go
+++ b/api/client/agents.go
@@ -21,10 +21,12 @@ import (
 	"github.com/Mierdin/todd/hostresources"
 )
 
-// Agent will query the ToDD server for a list of currently registered agents, and will display
+// Agents will query the ToDD server for a list of currently registered agents, and will display
 // a list of them to the user. Optionally, the user can provide a subargument containing the UUID of
 // a registered agent, and this function will output more detailed information about that agent.
-func (capi ClientApi) Agents(conf map[string]string, agentUuid string) {
+func (capi ClientApi) Agents(conf map[string]string, agentUuid string) (error, []defs.AgentAdvert) {
+
+	var agents []defs.AgentAdvert
 
 	var url string
 
@@ -37,14 +39,14 @@ func (capi ClientApi) Agents(conf map[string]string, agentUuid string) {
 	// Build the request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		panic(err)
+		return err, agents
 	}
 
 	// Send the request via a client
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(err)
+		return err, agents
 	}
 
 	// Defer the closing of the body
@@ -52,50 +54,32 @@ func (capi ClientApi) Agents(conf map[string]string, agentUuid string) {
 	// Read the content into a byte array
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		return err, agents
 	}
 
 	// Marshal API data into object
-	var records []defs.AgentAdvert
-	err = json.Unmarshal(body, &records)
+	err = json.Unmarshal(body, &agents)
 	if err != nil {
-		panic(err)
+		return err, agents
 	}
 
-	if len(records) == 0 {
+	return nil, agents
+}
+
+// DisplayAgents is responsible for displaying a set of Agents to the terminal
+func (capi ClientApi) DisplayAgents(agents []defs.AgentAdvert, detail bool) error {
+
+	if len(agents) == 0 {
 		fmt.Println("No agents found.")
-		os.Exit(0)
+		return nil
 	} else {
-		if records[0].Uuid == "" {
+		if agents[0].Uuid == "" {
 			fmt.Println("No agents found.")
-			os.Exit(0)
+			return nil
 		}
 	}
 
-	// If no UUID was provided, get all agents
-	if agentUuid == "" {
-
-		w := new(tabwriter.Writer)
-
-		// Format in tab-separated columns with a tab stop of 8.
-		w.Init(os.Stdout, 0, 8, 0, '\t', 0)
-		fmt.Fprintln(w, "UUID\tEXPIRES\tADDR\tFACT SUMMARY\tCOLLECTOR SUMMARY")
-
-		for i := range records {
-			fmt.Fprintf(
-				w,
-				"%s\t%s\t%s\t%s\t%s\n",
-				hostresources.TruncateID(records[i].Uuid),
-				records[i].Expires,
-				records[i].DefaultAddr,
-				records[i].FactSummary(),
-				records[i].CollectorSummary(),
-			)
-		}
-		fmt.Fprintln(w)
-		w.Flush()
-
-	} else {
+	if detail {
 
 		// TODO(moswalt): if nothing found, API should return either null or empty slice, and client should handle this
 		tmpl, err := template.New("test").Parse(
@@ -106,16 +90,39 @@ Facts:
 {{.PPFacts}}` + "\n")
 
 		if err != nil {
-			panic(err)
+			return err
 		}
 
 		// Output retrieved data
-		for i := range records {
-			err = tmpl.Execute(os.Stdout, records[i])
+		for i := range agents {
+			err = tmpl.Execute(os.Stdout, agents[i])
 			if err != nil {
-				panic(err)
+				return err
 			}
 		}
+
+	} else {
+		w := new(tabwriter.Writer)
+
+		// Format in tab-separated columns with a tab stop of 8.
+		w.Init(os.Stdout, 0, 8, 0, '\t', 0)
+		fmt.Fprintln(w, "UUID\tEXPIRES\tADDR\tFACT SUMMARY\tCOLLECTOR SUMMARY")
+
+		for i := range agents {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\n",
+				hostresources.TruncateID(agents[i].Uuid),
+				agents[i].Expires,
+				agents[i].DefaultAddr,
+				agents[i].FactSummary(),
+				agents[i].CollectorSummary(),
+			)
+		}
+		fmt.Fprintln(w)
+		w.Flush()
+
 	}
 
+	return nil
 }

--- a/api/client/agents_test.go
+++ b/api/client/agents_test.go
@@ -1,0 +1,77 @@
+/*
+   Unit testing for Agents (Client API)
+
+   Copyright 2016 Matt Oswalt. Use or modification of this
+   source code is governed by the license provided here:
+   https://github.com/Mierdin/todd/blob/master/LICENSE
+*/
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mierdin/todd/agent/defs"
+)
+
+// TestAgents tests the ability for the Agents client API call to function correctly
+func TestAgents(t *testing.T) {
+
+	agentJSON := `
+[
+  {
+    "Uuid": "aaaaaaaaaaaaaaaaaaaaaa",
+    "DefaultAddr": "192.168.0.1",
+    "Expires": 27000000000,
+    "LocalTime": "2016-03-25T08:03:11.378211992Z",
+    "Facts": {
+      "Hostname": [
+        "testmachine"
+      ]
+    },
+    "FactCollectors": {
+      "get_addresses": "aaaaaaaaaaaaaaaaaaaaaa",
+      "get_hostname": "aaaaaaaaaaaaaaaaaaaaaa"
+    },
+    "Testlets": {
+      "iperf": "aaaaaaaaaaaaaaaaaaaaaa",
+      "ping": "aaaaaaaaaaaaaaaaaaaaaa"
+    }
+  }
+]
+`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, agentJSON)
+	}))
+	defer ts.Close()
+
+	agentsUrl := fmt.Sprintf("%s/v1/agent", ts.URL)
+
+	var capi ClientApi
+	err, agents := capi.Agents(
+		map[string]string{
+			"host": strings.Split(strings.Replace(agentsUrl, "http://", "", 1), ":")[0],
+			"port": strings.Split(strings.Replace(agentsUrl, "http://", "", 1), ":")[1],
+		}, "",
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(agents) != 1 {
+		t.Error("Incorrect number of agents found")
+	}
+}
+
+func TestDisplayAgents(t *testing.T) {
+	var capi ClientApi
+	err := capi.DisplayAgents([]defs.AgentAdvert{}, false)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/client/main.go
+++ b/client/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	capi "github.com/Mierdin/todd/api/client"
@@ -50,13 +51,18 @@ func main() {
 			Name:  "agents",
 			Usage: "Show ToDD agent information",
 			Action: func(c *cli.Context) {
-				clientapi.Agents(
+				err, agents := clientapi.Agents(
 					map[string]string{
 						"host": host,
 						"port": port,
 					},
 					c.Args().First(),
 				)
+				if err != nil {
+					fmt.Println(err)
+					os.Exit(1)
+				}
+				clientapi.DisplayAgents(agents, !(c.Args().First() == ""))
 			},
 		},
 

--- a/client/main.go
+++ b/client/main.go
@@ -51,7 +51,7 @@ func main() {
 			Name:  "agents",
 			Usage: "Show ToDD agent information",
 			Action: func(c *cli.Context) {
-				err, agents := clientapi.Agents(
+				agents, err := clientapi.Agents(
 					map[string]string{
 						"host": host,
 						"port": port,

--- a/config/configparser.go
+++ b/config/configparser.go
@@ -13,45 +13,63 @@ import (
 	"gopkg.in/gcfg.v1"
 )
 
+type AMQP struct {
+	User     string
+	Password string
+	Host     string
+	Port     string
+}
+
+type API struct {
+	Host string
+	Port string
+}
+
+type Assets struct {
+	IP   string
+	Port string
+}
+
+type Comms struct {
+	Plugin string
+}
+
+type DB struct {
+	IP     string
+	Port   string
+	Plugin string
+}
+
+type TSDB struct {
+	IP     string
+	Port   string
+	Plugin string
+}
+
+type Testing struct {
+	Timeout int // seconds
+}
+
+type Grouping struct {
+	Interval int // seconds
+}
+
+type LocalResources struct {
+	DefaultInterface string
+	OptDir           string
+	IPAddrOverride   string
+}
+
 type Config struct {
-	API struct {
-		Host string
-		Port string
-	}
-	AMQP struct {
-		User     string
-		Password string
-		Host     string
-		Port     string
-	}
-	Comms struct {
-		Plugin string
-	}
-	Assets struct {
-		IP   string
-		Port string
-	}
-	DB struct {
-		IP     string
-		Port   string
-		Plugin string
-	}
-	TSDB struct {
-		IP     string
-		Port   string
-		Plugin string
-	}
-	Testing struct {
-		Timeout int
-	}
-	Grouping struct {
-		Interval int // seconds
-	}
-	LocalResources struct {
-		DefaultInterface string
-		OptDir           string
-		IPAddrOverride   string
-	}
+	AMQP           AMQP
+	API            API
+	Assets         Assets
+	Comms          Comms
+	DB             DB
+	TSDB           TSDB
+	Testing        Testing
+	Grouping       Grouping
+	LocalResources LocalResources
 }
 
 func GetConfig(cfgpath string) Config {


### PR DESCRIPTION
A few changes:

- (main change) - Added unit testing structure for the "client" portion of the ToDD API. Provided example in agents_test.go
- Broke out config structs so that they can be better leveraged during testing
- refactored agents.go to return an error condition, and a slice of Agent definitions.