### PR TITLE
Agent reconnect functionality

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -68,7 +68,14 @@ func main() {
 	var tc = comms.NewToDDComms(cfg)
 
 	// Spawn goroutine to listen for tasks issued by server
-	go tc.CommsPackage.ListenForTasks(uuid) // Need to convert this to a generic "listenfortasks" function. This will offload incoming messages
+	go func() {
+		for {
+			tc.CommsPackage.ListenForTasks(uuid)
+			if err != nil {
+				log.Warn("ListenForTasks reported a failure. Trying again...")
+			}
+		}
+	}()
 
 	// Watch for changes to group membership
 	go tc.CommsPackage.WatchForGroup()
@@ -97,7 +104,10 @@ func main() {
 		}
 
 		// Advertise this agent
-		tc.CommsPackage.AdvertiseAgent(me)
+		err := tc.CommsPackage.AdvertiseAgent(me)
+		if err != nil {
+			log.Error("Failed to advertise agent after several retries")
+		}
 
 		time.Sleep(15 * time.Second) // TODO(moswalt): make configurable
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -70,7 +70,7 @@ func main() {
 	// Spawn goroutine to listen for tasks issued by server
 	go func() {
 		for {
-			tc.CommsPackage.ListenForTasks(uuid)
+			err := tc.CommsPackage.ListenForTasks(uuid)
 			if err != nil {
 				log.Warn("ListenForTasks reported a failure. Trying again...")
 			}

--- a/comms/comms.go
+++ b/comms/comms.go
@@ -29,13 +29,13 @@ type CommsPackage interface {
 	// TODO(mierdin) best way to document interface or function args?
 
 	// (agent advertisement to advertise)
-	AdvertiseAgent(defs.AgentAdvert)
+	AdvertiseAgent(defs.AgentAdvert) error
 
 	// (map of assets:hashes)
 	ListenForAgent(map[string]map[string]string)
 
 	// (uuid)
-	ListenForTasks(string)
+	ListenForTasks(string) error
 
 	// (queuename, task)
 	SendTask(string, tasks.Task)
@@ -43,7 +43,7 @@ type CommsPackage interface {
 	// watches for new group membership instructions in the cache and reregisters
 	WatchForGroup()
 
-	ListenForGroupTasks(string, chan bool)
+	ListenForGroupTasks(string, chan bool) error
 
 	ListenForResponses(*chan bool)
 	SendResponse(responses.Response)

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -61,7 +61,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 		}
 
 		retries++
-		log.Warnf("Failure connecting to RabbitMQ - retry #%s", retries)
+		log.Warnf("Failure connecting to RabbitMQ - retry #%s", string(retries))
 		time.Sleep(1 * time.Second)
 	}
 	defer conn.Close()
@@ -391,7 +391,7 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 		}
 
 		retries++
-		log.Warnf("Failure connecting to RabbitMQ - retry #%s", retries)
+		log.Warnf("Failure connecting to RabbitMQ - retry #%s", string(retries))
 		time.Sleep(1 * time.Second)
 	}
 	defer conn.Close()
@@ -642,7 +642,7 @@ func (rmq rabbitMQComms) ListenForGroupTasks(groupName string, dereg chan bool) 
 		}
 
 		retries++
-		log.Warnf("Failure connecting to RabbitMQ - retry #%s", retries)
+		log.Warnf("Failure connecting to RabbitMQ - retry #%s", string(retries))
 		time.Sleep(1 * time.Second)
 	}
 	defer conn.Close()

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -568,6 +568,8 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 
 	log.Infof(" [*] Waiting for messages. To exit press CTRL+C")
 	<-forever
+
+	return nil
 }
 
 // WatchForGroup should be run as a goroutine, like other background services. This is because it will itself spawn a goroutine to
@@ -594,7 +596,7 @@ rereg:
 
 	go func() {
 		for {
-			rmq.ListenForGroupTasks(group, dereg)
+			err := rmq.ListenForGroupTasks(group, dereg)
 			if err != nil {
 				log.Warn("ListenForGroupTasks reported a failure. Trying again...")
 			}
@@ -705,6 +707,8 @@ func (rmq rabbitMQComms) ListenForGroupTasks(groupName string, dereg chan bool) 
 	// This will block until something is sent into this channel. This is an indication that we wish to stop listening for
 	// new group tasks, ususally because we need to re-register onto a new queue
 	<-dereg
+
+	return nil
 }
 
 // SendResponse will send a response object onto the statically-defined queue for receiving such messages.

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -61,7 +61,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 		}
 
 		retries++
-		log.Warnf("Failure connecting to RabbitMQ - retry #%s", string(retries))
+		log.Warnf("Failure connecting to RabbitMQ - retry #%d", retries)
 		time.Sleep(1 * time.Second)
 	}
 	defer conn.Close()
@@ -391,7 +391,7 @@ func (rmq rabbitMQComms) ListenForTasks(uuid string) error {
 		}
 
 		retries++
-		log.Warnf("Failure connecting to RabbitMQ - retry #%s", string(retries))
+		log.Warnf("Failure connecting to RabbitMQ - retry #%d", retries)
 		time.Sleep(1 * time.Second)
 	}
 	defer conn.Close()
@@ -642,7 +642,7 @@ func (rmq rabbitMQComms) ListenForGroupTasks(groupName string, dereg chan bool) 
 		}
 
 		retries++
-		log.Warnf("Failure connecting to RabbitMQ - retry #%s", string(retries))
+		log.Warnf("Failure connecting to RabbitMQ - retry #%d", retries)
 		time.Sleep(1 * time.Second)
 	}
 	defer conn.Close()


### PR DESCRIPTION
In this PR I've added the bare minimum amount of changes to enable the agents to gracefully reconnect to rabbitmq in the event of a connection failure.

On the raspberry pi specifically, I ran into a few issues where the network wouldn't **really** be up by the time the agent wanted to start, which meant that it couldn't access RMQ. With the existing agent code, this meant the agent just outright quit, and required a manual restart.

There are a number of things I want to do to the rabbitmq.go file to reflect some of the improvements that @vCabbage made in other patches, but for now I'm focused on fixing this particular issue. A future PR will expand on these changes and improve the entire file.