### PR TITLE
Improved error handling

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     todddev.vm.host_name = "todddev"
     todddev.vm.network "private_network", type: "dhcp"
-    todddev.vm.network "public_network", ip: "10.12.0.70", bridge: "en4: Thunderbolt Ethernet"
+    todddev.vm.network "public_network", type: "dhcp"
     todddev.vm.provision "ansible" do |ansible|
         ansible.playbook = "scripts/ansible-todd-dev.yml"
     end

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -22,7 +22,7 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 
 	// If insufficient subargs were provided, error out
 	if objType == "" || objLabel == "" {
-		fmt.Println("Error, need to provide type and label")
+		fmt.Println("Error, need to provide type and label (Ex. 'todd delete group datacenter')")
 		os.Exit(1)
 	}
 

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -11,19 +11,19 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 )
 
 // Delete will send a request to remove an existing ToDD Object
-func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
+func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) error {
 
 	// If insufficient subargs were provided, error out
 	if objType == "" || objLabel == "" {
 		fmt.Println("Error, need to provide type and label (Ex. 'todd delete group datacenter')")
-		os.Exit(1)
+		return errors.New("invalid syntax")
 	}
 
 	// anonymous struct to hold our delete info
@@ -38,7 +38,7 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 	// Marshal deleteinfo into JSON
 	json_str, err := json.Marshal(deleteinfo)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Construct API request, and send POST to server for this object
@@ -48,14 +48,14 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 	var jsonByte = []byte(json_str)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonByte))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -63,10 +63,9 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 	if resp.Status == "200 OK" {
 		fmt.Println("[OK]")
 	} else {
-		fmt.Println("response Status:", resp.Status)
-		fmt.Println("response Headers:", resp.Header)
-		body, _ := ioutil.ReadAll(resp.Body)
-		fmt.Println("response Body:", string(body))
+		fmt.Println("500 Server Error")
+		return errors.new("500 Server Error")
 	}
 
+	return nil
 }

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -64,7 +63,7 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) e
 		fmt.Println("[OK]")
 	} else {
 		fmt.Println("500 Server Error")
-		return errors.new("500 Server Error")
+		return errors.New("500 Server Error")
 	}
 
 	return nil

--- a/api/server/object.go
+++ b/api/server/object.go
@@ -88,12 +88,13 @@ func (tapi ToDDApi) DeleteObject(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&deleteInfo)
 	if err != nil {
-		panic(err)
+		log.Errorln(err)
+		http.Error(w, "Internal Error", 500)
 	}
 
 	err = tapi.tdb.DeleteObject(deleteInfo["label"], deleteInfo["type"])
 	if err != nil {
-		log.Error(err)
-		panic(err)
+		log.Errorln(err)
+		http.Error(w, "Internal Error", 500)
 	}
 }

--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -49,7 +49,10 @@ func init() {
 
 func main() {
 
-	cfg := config.GetConfig(arg_config)
+	err, cfg := config.GetConfig(arg_config)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Set up cache
 	var ac = cache.NewAgentCache(cfg)

--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -49,7 +49,7 @@ func init() {
 
 func main() {
 
-	err, cfg := config.GetConfig(arg_config)
+	cfg, err := config.GetConfig(arg_config)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/todd-server/assets.go
+++ b/cmd/todd-server/assets.go
@@ -99,7 +99,7 @@ func hashAssets(dir string) map[string]string {
 	return hashes
 }
 
-// hashAssets returns a mapping of filenames to their SHA256 hash.
+// hashFiles returns a mapping of filenames to their SHA256 hash.
 //
 // dir is the path to the files on the filesystem.
 func hashFiles(dir string) (map[string]string, error) {

--- a/cmd/todd-server/main.go
+++ b/cmd/todd-server/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	todd_version := "0.0.1"
 
-	err, cfg := config.GetConfig(arg_config)
+	cfg, err := config.GetConfig(arg_config)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/todd-server/main.go
+++ b/cmd/todd-server/main.go
@@ -49,7 +49,10 @@ func main() {
 
 	todd_version := "0.0.1"
 
-	cfg := config.GetConfig(arg_config)
+	err, cfg := config.GetConfig(arg_config)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Start serving collectors and testlets, and retrieve map of names and hashes
 	assets := serveAssets(cfg)

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -87,7 +87,7 @@ func main() {
 			Name:  "delete",
 			Usage: "Delete ToDD object",
 			Action: func(c *cli.Context) {
-				clientapi.Delete(
+				err := clientapi.Delete(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -95,6 +95,10 @@ func main() {
 					c.Args().Get(0),
 					c.Args().Get(1),
 				)
+				if err != nil {
+					fmt.Println("ERROR - Are you sure you provided the right object type and/or label?")
+					os.Exit(1)
+				}
 			},
 		},
 

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -56,13 +56,13 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args().First(),
+					c.Args().Get(0),
 				)
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
-				clientapi.DisplayAgents(agents, !(c.Args().First() == ""))
+				clientapi.DisplayAgents(agents, !(c.Args().Get(0) == ""))
 			},
 		},
 
@@ -77,7 +77,7 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args().First(),
+					c.Args().Get(0),
 				)
 			},
 		},
@@ -92,8 +92,8 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args()[0],
-					c.Args()[1],
+					c.Args().Get(0),
+					c.Args().Get(1),
 				)
 			},
 		},
@@ -122,7 +122,7 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args()[0],
+					c.Args().Get(0),
 				)
 			},
 		},
@@ -162,7 +162,7 @@ func main() {
 						"sourceApp":   c.String("source-app"),
 						"sourceArgs":  c.String("source-args"),
 					},
-					c.Args()[0],
+					c.Args().Get(0),
 					c.Bool("j"),
 					c.Bool("y"),
 				)

--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	LocalResources LocalResources
 }
 
-func GetConfig(cfgpath string) (error, Config) {
+func GetConfig(cfgpath string) (Config, error) {
 	var cfg Config
 
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
@@ -78,5 +78,5 @@ func GetConfig(cfgpath string) (error, Config) {
 		log.Errorf("Error retrieving configuration at %s", cfgpath)
 	}
 
-	return err, cfg
+	return cfg, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ func GetConfig(cfgpath string) (Config, error) {
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
 	if err != nil {
 		log.Errorf("Error retrieving configuration at %s", cfgpath)
+		log.Errorf(err)
 	}
 
 	return cfg, err

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ func GetConfig(cfgpath string) (Config, error) {
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
 	if err != nil {
 		log.Errorf("Error retrieving configuration at %s", cfgpath)
-		log.Errorf(err)
+		log.Error(err)
 	}
 
 	return cfg, err

--- a/config/config.go
+++ b/config/config.go
@@ -70,14 +70,13 @@ type Config struct {
 	LocalResources LocalResources
 }
 
-func GetConfig(cfgpath string) Config {
+func GetConfig(cfgpath string) (error, Config) {
 	var cfg Config
 
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
 	if err != nil {
-		log.Error("Error retrieving configuration")
-		panic("Error retrieving configuration")
+		log.Errorf("Error retrieving configuration at %s", cfgpath)
 	}
 
-	return cfg
+	return err, cfg
 }

--- a/etc/server.cfg
+++ b/etc/server.cfg
@@ -31,6 +31,6 @@ Interval = 10
 Timeout = 30   # This is the timer (in seconds) that a test will be allowed to live
 
 [LocalResources]
-DefaultInterface = eth0
-IPAddrOverride = localhost # Normally, the DefaultInterface configuration option is used to get IP address. This overrides that in the event that it doesn't work
+DefaultInterface = eth2
+#IPAddrOverride = 192.168.0.1 # Normally, the DefaultInterface configuration option is used to get IP address. This overrides that in the event that it doesn't work
 OptDir = /opt/todd/server

--- a/scripts/start-containers.sh
+++ b/scripts/start-containers.sh
@@ -12,7 +12,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 branch="latest"
 toddimage=mierdin/todd:$branch
 
-alias dtodd='docker run --rm --net todd-network --name="todd-client" $image todd --host="todd-server.todd-network"'
+alias dtodd='docker run --rm --net todd-network --name="todd-client" $toddimage todd --host="todd-server.todd-network"'
 
 # Clean up old containers
 function cleanup {


### PR DESCRIPTION
A few improvements to the handling of error conditions

- Refactored GetConfig to return an error condition when there's a problem
- Additional information when there was a problem retrieving the configuration.
- Refactored ```Delete``` and replaced the myriad of ```os.Exit()``` and ``panic()``` statements with proper error return. Adjusted the ```todd``` entry point accordingly. This refactor will serve as a POC for refactoring the rest of the client functions.