### PR TITLE
Improved error handling

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -23,19 +23,21 @@ import (
 
 // Create is responsible for pushing a ToDD object to the server for eventual storage in whatever database is being used
 // It will send a ToddObject rendered as JSON to the "createobject" method of the ToDD API
-func (capi ClientApi) Create(conf map[string]string, yamlFileName string) {
+func (capi ClientApi) Create(conf map[string]string, yamlFileName string) error {
 
 	// Pull YAML from either stdin or from the filename if stdin is empty
 	yamlDef, err := getYAMLDef(yamlFileName)
 	if err != nil {
-		panic(err)
+		fmt.Println("Unable to read object definition")
+		return err
 	}
 
 	// Unmarshal YAML file into a BaseObject so we can peek into the metadata
 	var baseobj objects.BaseObject
 	err = yaml.Unmarshal(yamlDef, &baseobj)
 	if err != nil {
-		panic(err)
+		fmt.Println("YAML file not in correct format")
+		return err
 	}
 
 	// finalobj represents the object being created, regardless of type.
@@ -47,14 +49,16 @@ func (capi ClientApi) Create(conf map[string]string, yamlFileName string) {
 		var group_obj objects.GroupObject
 		err = yaml.Unmarshal(yamlDef, &group_obj)
 		if err != nil {
-			panic(err)
+			fmt.Println("Group YAML object not in correct format")
+			return err
 		}
 		finalobj = group_obj
 	case "testrun":
 		var testrun_obj objects.TestRunObject
 		err = yaml.Unmarshal(yamlDef, &testrun_obj)
 		if err != nil {
-			panic(err)
+			fmt.Println("Testrun YAML object not in correct format")
+			return err
 		}
 
 		if testrun_obj.Spec.TargetType == "group" {
@@ -73,14 +77,14 @@ func (capi ClientApi) Create(conf map[string]string, yamlFileName string) {
 
 	default:
 		fmt.Println("Invalid object type provided")
-		os.Exit(1)
+		return error.New("Invalid object type provided")
 	}
 
 	// Marshal the final object into JSON
 	json_str, err := json.Marshal(finalobj)
 	if err != nil {
-
-		panic(err)
+		fmt.Println("Problem marshalling the final object into JSON")
+		return err
 	}
 
 	// Construct API request, and send POST to server for this object
@@ -90,26 +94,23 @@ func (capi ClientApi) Create(conf map[string]string, yamlFileName string) {
 	var jsonByte = []byte(json_str)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonByte))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer resp.Body.Close()
 
-	// Print a regular OK message if object was written successfully - else print some debug info
+	// Print a regular OK message if object was created successfully - else print the HTTP status code
 	if resp.Status == "200 OK" {
 		fmt.Println("[OK]")
 	} else {
-		fmt.Println("response Status:", resp.Status)
-		fmt.Println("response Headers:", resp.Header)
-		body, _ := ioutil.ReadAll(resp.Body)
-		fmt.Println("response Body:", string(body))
-		os.Exit(1)
+		fmt.Println(resp.Status)
+		return errors.New(resp.Status)
 	}
 
 }
@@ -124,7 +125,7 @@ func getYAMLDef(yamlFileName string) ([]byte, error) {
 	// Quit if there's nothing on stdin, and there's no arg either
 	if yamlFileName == "" {
 		fmt.Println("Please provide definition file")
-		os.Exit(1)
+		return nil, error.New("Object definition file not provided")
 	}
 
 	// Read YAML file

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -11,6 +11,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -77,7 +78,7 @@ func (capi ClientApi) Create(conf map[string]string, yamlFileName string) error 
 
 	default:
 		fmt.Println("Invalid object type provided")
-		return error.New("Invalid object type provided")
+		return errors.New("Invalid object type provided")
 	}
 
 	// Marshal the final object into JSON
@@ -113,6 +114,7 @@ func (capi ClientApi) Create(conf map[string]string, yamlFileName string) error 
 		return errors.New(resp.Status)
 	}
 
+	return nil
 }
 
 // getYAMLDef reads YAML from either stdin or from the filename if stdin is empty
@@ -125,7 +127,7 @@ func getYAMLDef(yamlFileName string) ([]byte, error) {
 	// Quit if there's nothing on stdin, and there's no arg either
 	if yamlFileName == "" {
 		fmt.Println("Please provide definition file")
-		return nil, error.New("Object definition file not provided")
+		return nil, errors.New("Object definition file not provided")
 	}
 
 	// Read YAML file

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -22,7 +22,7 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 
 	// If insufficient subargs were provided, error out
 	if objType == "" || objLabel == "" {
-		fmt.Println("Error, need to provide type and label")
+		fmt.Println("Error, need to provide type and label (Ex. 'todd delete group datacenter')")
 		os.Exit(1)
 	}
 

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -58,12 +58,12 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) e
 	}
 	defer resp.Body.Close()
 
-	// Print a regular OK message if object was written successfully - else print some debug info
+	// Print a regular OK message if object was written successfully - else print the HTTP status code
 	if resp.Status == "200 OK" {
 		fmt.Println("[OK]")
 	} else {
-		fmt.Println("500 Server Error")
-		return errors.New("500 Server Error")
+		fmt.Println(resp.Status)
+		return errors.New(resp.Status)
 	}
 
 	return nil

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -11,19 +11,19 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 )
 
 // Delete will send a request to remove an existing ToDD Object
-func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
+func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) error {
 
 	// If insufficient subargs were provided, error out
 	if objType == "" || objLabel == "" {
 		fmt.Println("Error, need to provide type and label (Ex. 'todd delete group datacenter')")
-		os.Exit(1)
+		return errors.New("invalid syntax")
 	}
 
 	// anonymous struct to hold our delete info
@@ -38,7 +38,7 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 	// Marshal deleteinfo into JSON
 	json_str, err := json.Marshal(deleteinfo)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Construct API request, and send POST to server for this object
@@ -48,14 +48,14 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 	var jsonByte = []byte(json_str)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonByte))
 	if err != nil {
-		panic(err)
+		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(err)
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -63,10 +63,9 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) {
 	if resp.Status == "200 OK" {
 		fmt.Println("[OK]")
 	} else {
-		fmt.Println("response Status:", resp.Status)
-		fmt.Println("response Headers:", resp.Header)
-		body, _ := ioutil.ReadAll(resp.Body)
-		fmt.Println("response Body:", string(body))
+		fmt.Println("500 Server Error")
+		return errors.new("500 Server Error")
 	}
 
+	return nil
 }

--- a/api/client/delete.go
+++ b/api/client/delete.go
@@ -13,7 +13,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -64,7 +63,7 @@ func (capi ClientApi) Delete(conf map[string]string, objType, objLabel string) e
 		fmt.Println("[OK]")
 	} else {
 		fmt.Println("500 Server Error")
-		return errors.new("500 Server Error")
+		return errors.New("500 Server Error")
 	}
 
 	return nil

--- a/api/client/groups.go
+++ b/api/client/groups.go
@@ -20,21 +20,21 @@ import (
 )
 
 // Groups will query ToDD for a map containing current agent-to-group mappings
-func (capi ClientApi) Groups(conf map[string]string) {
+func (capi ClientApi) Groups(conf map[string]string) error {
 
 	url := fmt.Sprintf("http://%s:%s/v1/groups", conf["host"], conf["port"])
 
 	// Build the request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Send the request via a client
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Defer the closing of the body
@@ -42,14 +42,14 @@ func (capi ClientApi) Groups(conf map[string]string) {
 	// Read the content into a byte array
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Marshal API data into map
 	var groupmap map[string]string
 	err = json.Unmarshal(body, &groupmap)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	w := new(tabwriter.Writer)
@@ -68,5 +68,7 @@ func (capi ClientApi) Groups(conf map[string]string) {
 	}
 	fmt.Fprintln(w)
 	w.Flush()
+
+	return nil
 
 }

--- a/api/client/objects.go
+++ b/api/client/objects.go
@@ -9,6 +9,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -20,12 +21,12 @@ import (
 
 // Objects will query ToDD for all objects, with the type requested in the sub-arguments, and then display a list of those
 // objects to the user.
-func (capi ClientApi) Objects(conf map[string]string, objType string) {
+func (capi ClientApi) Objects(conf map[string]string, objType string) error {
 
 	// If no subarg was provided, instruct the user to provide the object type
 	if objType == "" {
 		fmt.Println("Please provide the object type")
-		os.Exit(1)
+		return errors.New("Object type not provided")
 	}
 
 	url := fmt.Sprintf("http://%s:%s/v1/object/%s", conf["host"], conf["port"], objType)
@@ -33,14 +34,14 @@ func (capi ClientApi) Objects(conf map[string]string, objType string) {
 	// Build the request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Send the request via a client
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	// Defer the closing of the body
@@ -48,7 +49,7 @@ func (capi ClientApi) Objects(conf map[string]string, objType string) {
 	// Read the content into a byte array
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		return err
 	}
 
 	parsed_objects := objects.ParseToddObjects(body)
@@ -71,5 +72,7 @@ func (capi ClientApi) Objects(conf map[string]string, objType string) {
 	}
 	fmt.Fprintln(w)
 	w.Flush()
+
+	return nil
 
 }

--- a/api/server/object.go
+++ b/api/server/object.go
@@ -88,12 +88,13 @@ func (tapi ToDDApi) DeleteObject(w http.ResponseWriter, r *http.Request) {
 
 	err := json.NewDecoder(r.Body).Decode(&deleteInfo)
 	if err != nil {
-		panic(err)
+		log.Errorln(err)
+		http.Error(w, "Internal Error", 500)
 	}
 
 	err = tapi.tdb.DeleteObject(deleteInfo["label"], deleteInfo["type"])
 	if err != nil {
-		log.Error(err)
-		panic(err)
+		log.Errorln(err)
+		http.Error(w, "Internal Error", 500)
 	}
 }

--- a/cmd/todd-agent/README.md
+++ b/cmd/todd-agent/README.md
@@ -1,1 +1,0 @@
-In order to compile the agent on Raspberry Pi, make sure to set the environment variable GOARM to "5"

--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -68,7 +68,10 @@ func main() {
 	go testing.WatchForFinishedTestRuns(cfg)
 
 	// Construct comms package
-	var tc = comms.NewToDDComms(cfg)
+	tc, err := comms.NewToDDComms(cfg)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Spawn goroutine to listen for tasks issued by server
 	go func() {

--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -49,7 +49,10 @@ func init() {
 
 func main() {
 
-	cfg := config.GetConfig(arg_config)
+	err, cfg := config.GetConfig(arg_config)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Set up cache
 	var ac = cache.NewAgentCache(cfg)

--- a/cmd/todd-agent/main.go
+++ b/cmd/todd-agent/main.go
@@ -49,7 +49,7 @@ func init() {
 
 func main() {
 
-	err, cfg := config.GetConfig(arg_config)
+	cfg, err := config.GetConfig(arg_config)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/todd-server/main.go
+++ b/cmd/todd-server/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	todd_version := "0.0.1"
 
-	err, cfg := config.GetConfig(arg_config)
+	cfg, err := config.GetConfig(arg_config)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/cmd/todd-server/main.go
+++ b/cmd/todd-server/main.go
@@ -49,7 +49,10 @@ func main() {
 
 	todd_version := "0.0.1"
 
-	cfg := config.GetConfig(arg_config)
+	err, cfg := config.GetConfig(arg_config)
+	if err != nil {
+		os.Exit(1)
+	}
 
 	// Start serving collectors and testlets, and retrieve map of names and hashes
 	assets := serveAssets(cfg)

--- a/cmd/todd-server/main.go
+++ b/cmd/todd-server/main.go
@@ -74,8 +74,19 @@ func main() {
 	}()
 
 	// Start listening for agent advertisements
-	var tc = comms.NewToDDComms(cfg)
-	go tc.CommsPackage.ListenForAgent(assets)
+	tc, err := comms.NewToDDComms(cfg)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	go func() {
+		for {
+			err := tc.CommsPackage.ListenForAgent(assets)
+			if err != nil {
+				log.Fatalf("Error listening for ToDD Agents")
+			}
+		}
+	}()
 
 	// Kick off group calculation in background
 	go func() {

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -87,7 +87,7 @@ func main() {
 			Name:  "delete",
 			Usage: "Delete ToDD object",
 			Action: func(c *cli.Context) {
-				clientapi.Delete(
+				err := clientapi.Delete(
 					map[string]string{
 						"host": host,
 						"port": port,
@@ -95,6 +95,10 @@ func main() {
 					c.Args().Get(0),
 					c.Args().Get(1),
 				)
+				if err != nil {
+					fmt.Println("ERROR - Are you sure you provided the right object type and/or label?")
+					os.Exit(1)
+				}
 			},
 		},
 

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -72,13 +72,17 @@ func main() {
 			Usage: "Create ToDD object (group, testrun, etc.)",
 			Action: func(c *cli.Context) {
 
-				clientapi.Create(
+				err := clientapi.Create(
 					map[string]string{
 						"host": host,
 						"port": port,
 					},
 					c.Args().Get(0),
 				)
+				if err != nil {
+					fmt.Println("Unable to create object on ToDD server.")
+					os.Exit(1)
+				}
 			},
 		},
 

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -56,13 +56,13 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args().First(),
+					c.Args().Get(0),
 				)
 				if err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}
-				clientapi.DisplayAgents(agents, !(c.Args().First() == ""))
+				clientapi.DisplayAgents(agents, !(c.Args().Get(0) == ""))
 			},
 		},
 
@@ -77,7 +77,7 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args().First(),
+					c.Args().Get(0),
 				)
 			},
 		},
@@ -92,8 +92,8 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args()[0],
-					c.Args()[1],
+					c.Args().Get(0),
+					c.Args().Get(1),
 				)
 			},
 		},
@@ -122,7 +122,7 @@ func main() {
 						"host": host,
 						"port": port,
 					},
-					c.Args()[0],
+					c.Args().Get(0),
 				)
 			},
 		},
@@ -162,7 +162,7 @@ func main() {
 						"sourceApp":   c.String("source-app"),
 						"sourceArgs":  c.String("source-args"),
 					},
-					c.Args()[0],
+					c.Args().Get(0),
 					c.Bool("j"),
 					c.Bool("y"),
 				)

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -111,12 +111,16 @@ func main() {
 			Name:  "groups",
 			Usage: "Show current agent-to-group mappings",
 			Action: func(c *cli.Context) {
-				clientapi.Groups(
+				err := clientapi.Groups(
 					map[string]string{
 						"host": host,
 						"port": port,
 					},
 				)
+				if err != nil {
+					fmt.Println("ERROR - Unable to obtain current group mapping")
+					os.Exit(1)
+				}
 			},
 		},
 
@@ -125,13 +129,17 @@ func main() {
 			Name:  "objects",
 			Usage: "Show information about installed group objects",
 			Action: func(c *cli.Context) {
-				clientapi.Objects(
+				err := clientapi.Objects(
 					map[string]string{
 						"host": host,
 						"port": port,
 					},
 					c.Args().Get(0),
 				)
+				if err != nil {
+					fmt.Println("ERROR - Unable to retrieve object")
+					os.Exit(1)
+				}
 			},
 		},
 

--- a/cmd/todd/main.go
+++ b/cmd/todd/main.go
@@ -170,7 +170,7 @@ func main() {
 			},
 			Usage: "Execute an already uploaded testrun object",
 			Action: func(c *cli.Context) {
-				clientapi.Run(
+				err := clientapi.Run(
 					map[string]string{
 						"host":        host,
 						"port":        port,
@@ -182,6 +182,11 @@ func main() {
 					c.Bool("j"),
 					c.Bool("y"),
 				)
+				if err != nil {
+					fmt.Println("ERROR - Problem running testrun")
+					os.Exit(1)
+				}
+
 			},
 		},
 	}

--- a/comms/comms.go
+++ b/comms/comms.go
@@ -47,8 +47,8 @@ type CommsPackage interface {
 
 	ListenForGroupTasks(string, chan bool) error
 
-	ListenForResponses(*chan bool)
-	SendResponse(responses.Response)
+	ListenForResponses(*chan bool) error
+	SendResponse(responses.Response) error
 }
 
 // toddComms is a struct to hold anything that satisfies the CommsPackage interface

--- a/comms/comms.go
+++ b/comms/comms.go
@@ -11,7 +11,7 @@
 package comms
 
 import (
-	"os"
+	"errors"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -26,19 +26,21 @@ import (
 // represents a list of things that the server and agents do on the message queue.
 type CommsPackage interface {
 
-	// TODO(mierdin) best way to document interface or function args?
+	// TODO(mierdin) best way to document interface or function args? I've tried to document
+	// them minimally below, but would like a better way to document the meaning behind
+	// the arguments defined here.
 
 	// (agent advertisement to advertise)
 	AdvertiseAgent(defs.AgentAdvert) error
 
 	// (map of assets:hashes)
-	ListenForAgent(map[string]map[string]string)
+	ListenForAgent(map[string]map[string]string) error
 
 	// (uuid)
 	ListenForTasks(string) error
 
 	// (queuename, task)
-	SendTask(string, tasks.Task)
+	SendTask(string, tasks.Task) error
 
 	// watches for new group membership instructions in the cache and reregisters
 	WatchForGroup()
@@ -56,7 +58,7 @@ type toddComms struct {
 
 // NewToDDComms will create a new instance of toddComms, and load the desired
 // CommsPackage-compatible comms package into it.
-func NewToDDComms(cfg config.Config) *toddComms {
+func NewToDDComms(cfg config.Config) (*toddComms, error) {
 
 	var tc toddComms
 
@@ -66,9 +68,9 @@ func NewToDDComms(cfg config.Config) *toddComms {
 		tc.CommsPackage = newRabbitMQComms(cfg)
 	default:
 		log.Error("Invalid comms plugin in config file")
-		os.Exit(1)
+		return nil, errors.New("Invalid comms plugin in config file")
 	}
 
-	return &tc
+	return &tc, nil
 
 }

--- a/comms/rabbitmq.go
+++ b/comms/rabbitmq.go
@@ -76,6 +76,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	conn, err := connectRabbitMQ(rmq.queueUrl)
 	if err != nil {
 		log.Error("(AdvertiseAgent) Failed to connect to RabbitMQ")
+		log.Debug(err)
 		return err
 	}
 	defer conn.Close()
@@ -83,6 +84,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	ch, err := conn.Channel()
 	if err != nil {
 		log.Error("Failed to open a channel")
+		log.Debug(err)
 		return err
 	}
 
@@ -99,6 +101,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	)
 	if err != nil {
 		log.Error("Failed to declare an exchange")
+		log.Debug(err)
 		return err
 	}
 
@@ -112,6 +115,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	)
 	if err != nil {
 		log.Error("Failed to declare a queue")
+		log.Debug(err)
 		return err
 	}
 
@@ -124,6 +128,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	)
 	if err != nil {
 		log.Error("Failed to bind exchange to queue")
+		log.Debug(err)
 		return err
 	}
 
@@ -131,6 +136,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 	json_data, err := json.Marshal(me)
 	if err != nil {
 		log.Error("Failed to marshal agent data from queue")
+		log.Debug(err)
 		return err
 	}
 
@@ -146,6 +152,7 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 		})
 	if err != nil {
 		log.Error("Failed to publish agent advertisement")
+		log.Debug(err)
 		return err
 	}
 
@@ -156,22 +163,23 @@ func (rmq rabbitMQComms) AdvertiseAgent(me defs.AgentAdvert) error {
 
 // ListenForAgent will listen on the message queue for new agent advertisements.
 // It is meant to be run as a goroutine
-func (rmq rabbitMQComms) ListenForAgent(assets map[string]map[string]string) {
+func (rmq rabbitMQComms) ListenForAgent(assets map[string]map[string]string) error {
 
 	// TODO(mierdin): does func param need to be a pointer?
 
 	conn, err := amqp.Dial(rmq.queueUrl)
 	if err != nil {
-		log.Error(err)
-		log.Error("Failed to connect to RabbitMQ")
-		os.Exit(1)
+		log.Error("(ListenForAgent) Failed to connect to RabbitMQ")
+		log.Debug(err)
+		return err
 	}
 	defer conn.Close()
 
 	ch, err := conn.Channel()
 	if err != nil {
 		log.Error("Failed to open a channel")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 	defer ch.Close()
 
@@ -185,7 +193,8 @@ func (rmq rabbitMQComms) ListenForAgent(assets map[string]map[string]string) {
 	)
 	if err != nil {
 		log.Error("Failed to declare a queue")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	msgs, err := ch.Consume(
@@ -199,7 +208,8 @@ func (rmq rabbitMQComms) ListenForAgent(assets map[string]map[string]string) {
 	)
 	if err != nil {
 		log.Error("Failed to register a consumer")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	forever := make(chan bool)
@@ -286,24 +296,27 @@ func (rmq rabbitMQComms) ListenForAgent(assets map[string]map[string]string) {
 
 	log.Infof(" [*] Waiting for messages. To exit press CTRL+C")
 	<-forever
+
+	return nil
 }
 
 // SendTask will send a task object onto the specified queue ("queueName"). This could be an agent UUID, or a group name. Agents
 // that have been added to a group
-func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) {
+func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) error {
 
 	conn, err := amqp.Dial(rmq.queueUrl)
 	if err != nil {
-		log.Error(err)
-		log.Error("Failed to connect to RabbitMQ")
-		os.Exit(1)
+		log.Error("(ListenForAgent) Failed to connect to RabbitMQ")
+		log.Debug(err)
+		return err
 	}
 	defer conn.Close()
 
 	ch, err := conn.Channel()
 	if err != nil {
 		log.Error("Failed to open a channel")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 	defer ch.Close()
 
@@ -318,7 +331,8 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) {
 	)
 	if err != nil {
 		log.Error("Failed to declare an exchange")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	_, err = ch.QueueDeclare(
@@ -331,7 +345,8 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) {
 	)
 	if err != nil {
 		log.Error("Failed to declare a queue")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	err = ch.QueueBind(
@@ -343,13 +358,15 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) {
 	)
 	if err != nil {
 		log.Error("Failed to bind exchange to queue")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	json_data, err := json.Marshal(task)
 	if err != nil {
 		log.Error("Failed to marshal object data")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	err = ch.Publish(
@@ -363,10 +380,13 @@ func (rmq rabbitMQComms) SendTask(queueName string, task tasks.Task) {
 		})
 	if err != nil {
 		log.Error("Failed to publish a task onto message queue")
-		os.Exit(1)
+		log.Debug(err)
+		return err
 	}
 
 	log.Debugf("Sent task to %s: %s", queueName, json_data)
+
+	return nil
 }
 
 // ListenForTasks is a method that recieves task notices from the server

--- a/config/config.go
+++ b/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	LocalResources LocalResources
 }
 
-func GetConfig(cfgpath string) (error, Config) {
+func GetConfig(cfgpath string) (Config, error) {
 	var cfg Config
 
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
@@ -78,5 +78,5 @@ func GetConfig(cfgpath string) (error, Config) {
 		log.Errorf("Error retrieving configuration at %s", cfgpath)
 	}
 
-	return err, cfg
+	return cfg, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ func GetConfig(cfgpath string) (Config, error) {
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
 	if err != nil {
 		log.Errorf("Error retrieving configuration at %s", cfgpath)
+		log.Errorf(err)
 	}
 
 	return cfg, err

--- a/config/config.go
+++ b/config/config.go
@@ -76,7 +76,7 @@ func GetConfig(cfgpath string) (Config, error) {
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
 	if err != nil {
 		log.Errorf("Error retrieving configuration at %s", cfgpath)
-		log.Errorf(err)
+		log.Error(err)
 	}
 
 	return cfg, err

--- a/config/config.go
+++ b/config/config.go
@@ -70,14 +70,13 @@ type Config struct {
 	LocalResources LocalResources
 }
 
-func GetConfig(cfgpath string) Config {
+func GetConfig(cfgpath string) (error, Config) {
 	var cfg Config
 
 	err := gcfg.ReadFileInto(&cfg, cfgpath)
 	if err != nil {
-		log.Error("Error retrieving configuration")
-		panic("Error retrieving configuration")
+		log.Errorf("Error retrieving configuration at %s", cfgpath)
 	}
 
-	return cfg
+	return err, cfg
 }

--- a/docs/installrpi.rst
+++ b/docs/installrpi.rst
@@ -67,6 +67,9 @@ Next, use make to compile ToDD. Be patient, the first step can take a while on t
     make
     sudo make install
 
+.. NOTE::
+
+    On some versions of Go, you may need to set the environment variable "GOARM" to "5".
 
 Run ToDD Agent
 --------------

--- a/server/grouping/grouping.go
+++ b/server/grouping/grouping.go
@@ -84,7 +84,11 @@ next:
 	}
 
 	// Send notifications to each agent to let them know what group they're in, so they can cache it
-	var tc = comms.NewToDDComms(cfg)
+	tc, err := comms.NewToDDComms(cfg)
+	if err != nil {
+		log.Fatalf("Error setting up ToDD Comms during group calculation")
+	}
+
 	for uuid, groupName := range groupmap {
 		setGroupTask := tasks.SetGroupTask{
 			GroupName: groupName,

--- a/server/testrun/testrun.go
+++ b/server/testrun/testrun.go
@@ -83,7 +83,10 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 	}
 
 	// Start listening for responses from agents
-	var tc = comms.NewToDDComms(cfg)
+	tc, err := comms.NewToDDComms(cfg)
+	if err != nil {
+		os.Exit(1) //TODO(mierdin): remove
+	}
 	stopListeningForResponses := make(chan bool, 1)
 	go tc.CommsPackage.ListenForResponses(&stopListeningForResponses)
 
@@ -152,7 +155,11 @@ func Start(cfg config.Config, trObj objects.TestRunObject, sourceOverrideMap map
 		var itrTask tasks.InstallTestRunTask
 		itrTask.Type = "InstallTestRun" //TODO(mierdin): This is an extra step. Maybe a factory function for the task could help here?
 		itrTask.Tr = targetTr
-		var tc = comms.NewToDDComms(cfg)
+
+		tc, err := comms.NewToDDComms(cfg)
+		if err != nil {
+			os.Exit(1) //TODO(mierdin): remove
+		}
 
 		// Send testrun to each agent UUID in the targets group
 		for uuid, _ := range testAgentMap["targets"] {
@@ -207,7 +214,10 @@ readyloop:
 		break
 	}
 
-	var tc = comms.NewToDDComms(cfg)
+	tc, err := comms.NewToDDComms(cfg)
+	if err != nil {
+		os.Exit(1) //TODO(mierdin): remove
+	}
 
 	// If this is a group target type, we want to make sure that the targets are set up and reporting a status of "testing"
 	// before we spin up the source tests


### PR DESCRIPTION
A few improvements to the handling of error conditions

- Refactored GetConfig to return an error condition when there's a problem
- Additional information when there was a problem retrieving the configuration.
- Refactored all ```client``` API functions by replacing the myriad of ```os.Exit()``` and ```panic()``` statements with proper error return. Naturally, adjusted the ToDD client as well to handle these errors and exist accordingly

This should address a number of concerns raised in Slack as well as Github issues regarding the helpfulness of the output of the ```todd``` client when things go wrong.